### PR TITLE
Update fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,8 +23,8 @@
     "aier.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.11.1",
+    "fabricloader": ">=0.9.0",
     "fabric": "*",
-    "minecraft": "1.16.5"
+    "minecraft": "~1.16.5"
   }
 }


### PR DESCRIPTION
- 兼容1.16.5的mod必定兼容1.16.2-1.16.5
- Fabric Loader的限制不要太死（因为我现在还没有升级到0.11.1；一般的Mod在0.7.0甚至都能跑）
-------------------------
- Any 1.16.5-compatible mod must be compatible from 1.16.2.
- Version of Fabric Loader should not be too high.